### PR TITLE
Add PyPI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [comment]: <> ([![Build Status]&#40;https://travis-ci.org/PASTAplus/metapype-eml.svg?branch=master&#41;]&#40;https://travis-ci.org/PASTAplus/metapype-eml&#41;)
 
 ![metapype](https://github.com/PASTAplus/metapype-eml/workflows/metapype-build/badge.svg)
+![PyPI - Version](https://img.shields.io/pypi/v/metapype?color=blue)
 
 
 


### PR DESCRIPTION
Add a PyPI badge to notify users that the package can be installed using `pip install`.